### PR TITLE
Update gem homepage

### DIFF
--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.version = "0.19.0"
   s.summary = "GraphQL Client"
   s.description = "A Ruby library for declaring, composing and executing GraphQL queries"
-  s.homepage = "https://github.com/github/graphql-client"
+  s.homepage = "https://github.com/github-community-projects/graphql-client"
   s.license = "MIT"
 
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]


### PR DESCRIPTION
I noticed that https://rubygems.org/gems/graphql-client 0.19.0 has been released but wondered why there is no 0.19.0 code on https://github.com/github/graphql-client.

Has the graphql-client repository moved here? If so, I thought I should update the gem's homepage attribute.