### PR TITLE
Fix normalize error paths

### DIFF
--- a/lib/graphql/client/errors.rb
+++ b/lib/graphql/client/errors.rb
@@ -21,7 +21,7 @@ module GraphQL
         errors.each do |error|
           path = ["data"]
           current = data
-          error.fetch("path", []).each do |key|
+          error["path"].to_a.each do |key|
             break unless current
             path << key
             current = current[key]

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -169,6 +169,26 @@ class TestClientErrors < MiniTest::Test
       ]
     }
     assert_equal expected, actual
+
+    actual = {
+      "data" => nil,
+      "errors" => [
+        {
+          "message" => "error",
+          "path" => nil
+        }
+      ]
+    }
+    GraphQL::Client::Errors.normalize_error_paths(actual["data"], actual["errors"])
+    expected = {
+      "data" => nil,
+      "errors" => [
+        {
+          "message" => "error",
+          "normalizedPath" => %w(data)
+        }
+      ]
+    }
   end
 
   def test_filter_nested_errors_by_path

--- a/test/test_client_errors.rb
+++ b/test/test_client_errors.rb
@@ -185,10 +185,12 @@ class TestClientErrors < MiniTest::Test
       "errors" => [
         {
           "message" => "error",
-          "normalizedPath" => %w(data)
-        }
-      ]
+          "path" => nil,
+          "normalizedPath" => %w(data),
+        },
+      ],
     }
+    assert_equal expected, actual
   end
 
   def test_filter_nested_errors_by_path


### PR DESCRIPTION
Hello :wave:,
Thank you for continuing the project!
I have already placed this [PR](https://github.com/github/graphql-client/pull/246) in the old repository and therefore now here, because in my opinion it would still be relevant.

I'm consuming a GraphQL-interface, which returns error-payloads like that:
```json
{
      "data": null,
      "errors": [
        {
          "message": "error",
          "path": null
        }
      ]
}
``` 
This caused a NoMethodError: undefined method `each' for nil:NilClass
This PR would fix the behavior.

Thanks
best regards
Armin