### PR TITLE
Update graphql minimum version

### DIFF
--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
   s.add_dependency "activesupport", ">= 3.0"
-  s.add_dependency "graphql"
+  s.add_dependency "graphql", ">= 2.1.0"
 
   s.add_development_dependency "actionpack", ">= 3.2.22"
   s.add_development_dependency "erubi", "~> 1.6"


### PR DESCRIPTION
I'm not certain, but I believe the visitor changes require graphql 2.1.0+, so here is a PR to bump the gem spec requirements, though @rmosolgo you'll likely know for certain if this needs changed or not.

Btw, thanks for taking the initiative and getting updates to this library rolling.