### PR TITLE
Tapioca compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_client.rb
+++ b/lib/tapioca/dsl/compilers/graphql_client.rb
@@ -58,8 +58,10 @@ module Tapioca
                    sub_type = type_for(definition.of_klass, nilable: nilable)
                    "T::Array[#{sub_type}]" if sub_type
                  when GraphQL::Client::Schema::ScalarType, GraphQL::Client::Schema::EnumType
-                   Helpers::GraphqlTypeHelper
-                     .type_for(GraphQL::Schema::NonNull.new(definition.type))
+                   argument = GraphQL::Schema::Argument.new(owner: nil)
+                   argument.type = GraphQL::Schema::NonNull.new(definition.type)
+                   Tapioca::Dsl::Helpers::GraphqlTypeHelper
+                     .type_for(argument)
                  when GraphQL::Client::Schema::UnionType, GraphQL::Client::Schema::InterfaceType
                    nil
                  when Class

--- a/lib/tapioca/dsl/compilers/graphql_client.rb
+++ b/lib/tapioca/dsl/compilers/graphql_client.rb
@@ -1,0 +1,78 @@
+# typed: true
+# frozen_string_literal: true
+
+require "graphql/client"
+require "graphql/client/http"
+require "tapioca/dsl/helpers/graphql_type_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class GraphqlClient < Compiler
+        extend T::Sig
+
+        # This is a hack to make Sorbet happy.
+        # It's necessary because there's no static class that implements this interface.
+        # See `GraphQL::Client::Schema::ObjectType.new`
+        class TypeClass
+          def self.fields; end
+        end
+
+        ConstantType = type_member { { fixed: T.class_of(TypeClass) } }
+
+        sig { override.returns(T::Enumerable[Module]) }
+        def self.gather_constants
+          all_modules
+            .select { |mod| mod.singleton_class < GraphQL::Client::Schema::ClassMethods }
+            .flat_map do |mod|
+              mod_name = qualified_name_of(mod)
+              next unless mod_name # Ignore anonymous modules
+
+              mod.constants.map { |const| "#{mod_name}::#{const}".constantize }
+            end
+            .select { |c| c.is_a?(Class) }
+        end
+
+        sig { override.void }
+        def decorate
+          root.create_path(constant) do |klass|
+            constant.fields.each do |name, definition|
+              define_field(klass, name, definition)
+            end
+          end
+        end
+
+        private
+
+        def define_field(klass, name, definition)
+          type = type_for(definition)
+          klass.create_method(name.to_s.underscore, return_type: type) if type
+        end
+
+        def type_for(definition, nilable: true)
+          type = case definition
+                 when GraphQL::Client::Schema::NonNullType
+                   nilable = false
+                   type_for(definition.of_klass, nilable: false)
+                 when GraphQL::Client::Schema::ListType
+                   sub_type = type_for(definition.of_klass, nilable: nilable)
+                   "T::Array[#{sub_type}]" if sub_type
+                 when GraphQL::Client::Schema::ScalarType, GraphQL::Client::Schema::EnumType
+                   Helpers::GraphqlTypeHelper
+                     .type_for(GraphQL::Schema::NonNull.new(definition.type))
+                 when GraphQL::Client::Schema::UnionType, GraphQL::Client::Schema::InterfaceType
+                   nil
+                 when Class
+                   definition.name
+                 else
+                   raise "Unrecognised definition: #{definition}"
+                 end
+          return unless type
+
+          type = "T.nilable(#{type})" if nilable && type != "T.untyped"
+          type
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a tapioca compiler to automatically generate RBIs for dynamically generated GraphQL type classes.

## How it works

The compiler is opt-in, as it relies on a `Types` constant being defined with all the `GraphQL::Client.types`.
To make it pick up and generate RBIs for your client, you just need to set this constant in your API module:

```ruby
module SWAPI
  # Configure GraphQL endpoint using the basic HTTP network adapter.
  HTTP = GraphQL::Client::HTTP.new("https://example.com/graphql") do
    ...
  end  

  Schema = GraphQL::Client.load_schema(HTTP)
  Client = GraphQL::Client.new(schema: Schema, execute: HTTP)

  # This is what triggers the compiler discovery of the type classes and their RBI generation
  const_set(:Types, Client.types)
end
```

Once that is added and `tapioca dsl` is run, RBIs for `SWAPI::Types::<name>` will be generated, allowing you to use them in Sorbet signatures. Obviously, the `Types` constant can be called anything you'd like, as far as its value it set to `Client.types`.