### PR TITLE
Add Release GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Release to RubyGems
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions workflow that will build and publish a new version of the gem to RubyGems. The workflow follows the pattern described in [RubyGems' "Trusted Publishing" documentation](https://guides.rubygems.org/trusted-publishing/releasing-gems/).

The workflow is triggered whenever a new Release is published by anyone with permissions to do so on the project's GitHub repository. This should work for pre-release versions, as well.

Releases may be created via [the website](https://github.com/github-community-projects/graphql-client/releases) or by using the GitHub CLI:

```sh
gh release create v0.1.0 --generate-notes
```

Being sure to swap out `v0.1.0` with an appropriate (new or existing) tag, of course. Note that draft releases and/or editing existing releases will not re-trigger this workflow.

> [!NOTE]
> Anyone with the ability to create Releases on this project will be able to indirectly trigger this workflow and publish a new version to RubyGems. It may be worth auditing the "Collaborators" settings on GitHub and the "Ownership" settings on RubyGems.

This commit follows up on [my question/comment](https://github.com/github-community-projects/graphql-client/pull/3#issuecomment-1910521991) on #3.

## RubyGems Owner To-Do

In order to enable this workflow, a gem owner (@rmosolgo, that'd be you!) will need to configure a Trusted Publisher on RubyGems. [This tutorial](https://guides.rubygems.org/trusted-publishing/adding-a-publisher/) outlines the necessary steps.

1. Navigate to https://rubygems.org/gems/graphql-client/trusted_publishers
2. Authenticate (if necessary)
3. Click "Create" on the Trusted Publishers page
4. Select "GitHub Actions" as the publisher type
5. You may need to update the repository owner field to point to be "github-community-projects"
6. Set "release.yml" as the workflow name
7. Click "Create Rubygem trusted publisher"

That _should_ be it on the RubyGems side of things.

## Suggested Improvement

I didn't add this in the PR, but:

On some of my projects, I re-run my CI workflow before running the job that releases a gem as a last-minute backstop against anything strange happening. You can see that in action [in this workflow file](https://github.com/jgarber623/micromicro/blob/main/.github/workflows/publish.yml) (reproduced and modified here):

```yaml
jobs:
  ci:
    name: CI
    uses: ./.github/workflows/ci.yml
  release:
    name: Release to RubyGems
    permissions:
      contents: write
      id-token: write
    # Run the `ci` job before running the `release` job:
    needs: ci
    # etc. etc. etc.
```

The `ci.yml` workflow would need a small update to its trigger configuration to support this:

```yaml
on:
  push:
  pull_request:
  workflow_call:
```

Relevant documentation:

- [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
- [Workflow syntax for GitHub Actions: `on.workflow_call`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_call)

## Thanks!

Thanks for considering this change to this gem's workflow. Adopting this process should streamline the development cycle while also maintaining security and trust. Looking forward to your feedback.