### PR TITLE
Address the deprecation warnings from the logger

### DIFF
--- a/lib/graphql/client/log_subscriber.rb
+++ b/lib/graphql/client/log_subscriber.rb
@@ -16,11 +16,18 @@ module GraphQL
     #   GraphQL::Client::LogSubscriber.attach_to :graphql
     #
     class LogSubscriber < ActiveSupport::LogSubscriber
+      SHOULD_USE_KWARGS = private_instance_methods.include?(:mode_from)
+
       def query(event)
         logger.info do
           name = event.payload[:operation_name].gsub("__", "::")
           type = event.payload[:operation_type].upcase
-          color("#{name} #{type} (#{event.duration.round(1)}ms)", nil, true)
+
+          if SHOULD_USE_KWARGS
+            color("#{name} #{type} (#{event.duration.round(1)}ms)", nil, bold: true)
+          else
+            color("#{name} #{type} (#{event.duration.round(1)}ms)", nil, true)
+          end
         end
 
         logger.debug do
@@ -32,7 +39,12 @@ module GraphQL
         logger.error do
           name = event.payload[:operation_name].gsub("__", "::")
           message = event.payload[:message]
-          color("#{name} ERROR: #{message}", nil, true)
+
+          if SHOULD_USE_KWARGS
+            color("#{name} ERROR: #{message}", nil, bold: true)
+          else
+            color("#{name} ERROR: #{message}", nil, true)
+          end
         end
       end
     end


### PR DESCRIPTION
This PR https://github.com/rails/rails/pull/45976 has deprecated the optional argument for the `color` method in the `Active Support:: LogSubscriber`, and the `graphql-client` gem depends on the deprecated interface in the 
 `lib/graphql/client/log_subscriber.rb`. As a result, the following deprecation warning would appear when used with Rails 7.1.

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. ).
```

This PR updates the code to be compatible with both the latest rails and the older ones.

cc @erikdstock @jonallured

