### PR TITLE
Broken error links.

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -338,7 +338,7 @@ module GraphQL
       end
 
       if allow_dynamic_queries == false && definition.name.nil?
-        raise DynamicQueryError, "expected definition to be assigned to a static constant https://git.io/vXXSE"
+        raise DynamicQueryError, "expected definition to be assigned to a static constant https://github.com/github-community-projects/graphql-client/blob/master/guides/dynamic-query-error.md"
       end
 
       variables = deep_stringify_keys(variables)

--- a/lib/graphql/client/collocated_enforcement.rb
+++ b/lib/graphql/client/collocated_enforcement.rb
@@ -26,7 +26,7 @@ module GraphQL
         return yield if Thread.current[:query_result_caller_location_ignore]
 
         if (location.path != path) && !(WHITELISTED_GEM_NAMES.any? { |g| location.path.include?("gems/#{g}") })
-          error = NonCollocatedCallerError.new("#{method} was called outside of '#{path}' https://git.io/v1syX")
+          error = NonCollocatedCallerError.new("#{method} was called outside of '#{path}' https://github.com/github-community-projects/graphql-client/blob/master/guides/collocated-call-sites.md")
           error.set_backtrace(caller(2))
           raise error
         end

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -255,13 +255,13 @@ module GraphQL
               end
 
               unless field
-                raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type.graphql_name} type. https://git.io/v1y3m"
+                raise UnimplementedFieldError, "undefined field `#{e.name}' on #{type.graphql_name} type. https://github.com/github-community-projects/graphql-client/blob/master/guides/unimplemented-field-error.md"
               end
 
               if @data.key?(field.name)
-                raise ImplicitlyFetchedFieldError, "implicitly fetched field `#{field.name}' on #{type} type. https://git.io/v1yGL"
+                raise ImplicitlyFetchedFieldError, "implicitly fetched field `#{field.name}' on #{type} type. https://github.com/github-community-projects/graphql-client/blob/master/guides/implicitly-fetched-field-error.md"
               else
-                raise UnfetchedFieldError, "unfetched field `#{field.name}' on #{type} type. https://git.io/v1y3U"
+                raise UnfetchedFieldError, "unfetched field `#{field.name}' on #{type} type. https://github.com/github-community-projects/graphql-client/blob/master/guides/unfetched-field-error.md"
               end
             end
           end

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -347,7 +347,7 @@ class TestQueryResult < Minitest::Test
       person.nickname
       flunk
     rescue GraphQL::Client::UnimplementedFieldError => e
-      assert_match "undefined field `nickname' on Person type. https://git.io/v1y3m", e.to_s
+      assert_match "undefined field `nickname' on Person type. https://github.com/github-community-projects/graphql-client/blob/master/guides/unimplemented-field-error.md", e.to_s
     end
   end
 
@@ -362,7 +362,7 @@ class TestQueryResult < Minitest::Test
 
     person = @client.query(Temp::Query).data.me
 
-    assert_raises GraphQL::Client::UnfetchedFieldError, "unfetched field `name' on Person type. https://git.io/v1y3U" do
+    assert_raises GraphQL::Client::UnfetchedFieldError, "unfetched field `name' on Person type. https://github.com/github-community-projects/graphql-client/blob/master/guides/unfetched-field-error.md" do
       person.name
     end
   end
@@ -378,7 +378,7 @@ class TestQueryResult < Minitest::Test
 
     person = @client.query(Temp::Query).data.me
 
-    assert_raises GraphQL::Client::UnfetchedFieldError, "unfetched field `firstName' on Person type. https://git.io/v1y3U" do
+    assert_raises GraphQL::Client::UnfetchedFieldError, "unfetched field `firstName' on Person type. https://github.com/github-community-projects/graphql-client/blob/master/guides/unfetched-field-error.md" do
       person.first_name
     end
   end
@@ -401,7 +401,7 @@ class TestQueryResult < Minitest::Test
 
     person = Temp::Person.new(@client.query(Temp::Query).data.me)
 
-    assert_raises GraphQL::Client::ImplicitlyFetchedFieldError, "implicitly fetched field `name' on Person type. https://git.io/v1yGL" do
+    assert_raises GraphQL::Client::ImplicitlyFetchedFieldError, "implicitly fetched field `name' on Person type. https://github.com/github-community-projects/graphql-client/blob/master/guides/implicitly-fetched-field-error.md" do
       person.name
     end
   end
@@ -424,7 +424,7 @@ class TestQueryResult < Minitest::Test
 
     person = Temp::Person.new(@client.query(Temp::Query).data.me)
 
-    assert_raises GraphQL::Client::ImplicitlyFetchedFieldError, "implicitly fetched field `firstName' on Person type. https://git.io/v1yGL" do
+    assert_raises GraphQL::Client::ImplicitlyFetchedFieldError, "implicitly fetched field `firstName' on Person type. https://github.com/github-community-projects/graphql-client/blob/master/guides/implicitly-fetched-field-error.md" do
       person.first_name
     end
   end
@@ -446,7 +446,7 @@ class TestQueryResult < Minitest::Test
 
     person = @client.query(Temp::Query).data.me
 
-    assert_raises GraphQL::Client::ImplicitlyFetchedFieldError, "implicitly fetched field `name' on Person type. https://git.io/v1yGL" do
+    assert_raises GraphQL::Client::ImplicitlyFetchedFieldError, "implicitly fetched field `name' on Person type. https://github.com/github-community-projects/graphql-client/blob/master/guides/implicitly-fetched-field-error.md" do
       person.name
     end
   end


### PR DESCRIPTION
https://git.io/??? links redirect to old repo name in `github` organisation. 

This patch updates them with direct links on docs in the new repo.

~It's just an example of the issue (**you don't have issues tab on your repo, otherwise I'd just submitted issue**, not code change), I think there's more broken links + tests + you probably want to keep them shortened (and git.io doesn't accept new links).~