### PR TITLE
Allow new enum values config

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -91,7 +91,7 @@ module GraphQL
       result
     end
 
-    def initialize(schema:, execute: nil, enforce_collocated_callers: false)
+    def initialize(schema:, execute: nil, enforce_collocated_callers: false, raise_on_unknown_enum_value: true)
       @schema = self.class.load_schema(schema)
       @execute = execute
       @document = GraphQL::Language::Nodes::Document.new(definitions: [])
@@ -101,7 +101,7 @@ module GraphQL
       if schema.is_a?(Class)
         @possible_types = schema.possible_types
       end
-      @types = Schema.generate(@schema)
+      @types = Schema.generate(@schema, raise_on_unknown_enum_value: raise_on_unknown_enum_value)
     end
 
     # A cache of the schema's merged possible types

--- a/lib/graphql/client/schema.rb
+++ b/lib/graphql/client/schema.rb
@@ -43,7 +43,7 @@ module GraphQL
         def set_class(type_name, klass)
           class_name = normalize_type_name(type_name)
 
-          if constants.include?(class_name.to_sym)
+          if const_defined?(class_name, false)
             raise ArgumentError,
               "Can't define #{class_name} to represent type #{type_name} " \
               "because it's already defined"
@@ -66,9 +66,10 @@ module GraphQL
         end
       end
 
-      def self.generate(schema)
+      def self.generate(schema, raise_on_unknown_enum_value: true)
         mod = Module.new
         mod.extend ClassMethods
+        mod.define_singleton_method(:raise_on_unknown_enum_value) { raise_on_unknown_enum_value }
 
         cache = {}
         schema.types.each do |name, type|

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -365,7 +365,7 @@ class TestSchemaType < Minitest::Test
       end
     end
 
-    types = GraphQL::Client::Schema.generate(schema, raise_on_unknown_enum_value: true)
+    types = GraphQL::Client::Schema.generate(schema)
 
     assert_equal person_type, types::Person.type
     assert_equal photo_type, types::Photo.type
@@ -397,7 +397,7 @@ class TestSchemaType < Minitest::Test
     end
 
     assert_raises ArgumentError do
-      GraphQL::Client::Schema.generate(schema, raise_on_unknown_enum_value: true)
+      GraphQL::Client::Schema.generate(schema)
     end
   end
 

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -73,7 +73,7 @@ class TestSchemaType < Minitest::Test
     end
   end
 
-  Types = GraphQL::Client::Schema.generate(Schema)
+  Types = GraphQL::Client::Schema.generate(Schema, raise_on_unknown_enum_value: true)
 
   def test_query_object_class
     assert_equal QueryType, Types::Query.type
@@ -149,6 +149,34 @@ class TestSchemaType < Minitest::Test
     refute Types::Plan::SMALL.free?
     assert Types::Plan::SMALL.small?
     refute Types::Plan::SMALL.large?
+
+    assert_raises GraphQL::Client::Error do
+      Types::Plan.cast("unknown_value")
+    end
+  end
+
+  def test_unknown_enum_values
+    size = Class.new(GraphQL::Schema::Enum) do
+      graphql_name "Size"
+      value "SMALL"
+      value "MEDIUM"
+      value "LARGE"
+    end
+
+    query_type = Class.new(GraphQL::Schema::Object) do
+      graphql_name "Query"
+      field :size, size, null: false
+    end
+
+    schema = Class.new(GraphQL::Schema) do
+      query query_type
+    end
+
+    types = GraphQL::Client::Schema.generate(schema, raise_on_unknown_enum_value: false)
+
+    assert_equal "unknown_value", types::Size.cast("unknown_value")
+    assert types::Size.cast("unknown_value").unknown_enum_value?
+    refute types::Size.cast("SMALL").unknown_enum_value?
   end
 
   def test_to_non_null_type
@@ -337,7 +365,7 @@ class TestSchemaType < Minitest::Test
       end
     end
 
-    types = GraphQL::Client::Schema.generate(schema)
+    types = GraphQL::Client::Schema.generate(schema, raise_on_unknown_enum_value: true)
 
     assert_equal person_type, types::Person.type
     assert_equal photo_type, types::Photo.type
@@ -369,7 +397,7 @@ class TestSchemaType < Minitest::Test
     end
 
     assert_raises ArgumentError do
-      GraphQL::Client::Schema.generate(schema)
+      GraphQL::Client::Schema.generate(schema, raise_on_unknown_enum_value: true)
     end
   end
 


### PR DESCRIPTION
- Adds a configuration for handling unknown enum values returned by the server
- An optimization that is being taken from https://github.com/github/graphql-client/pull/297