### PR TITLE
Remove unused local variable

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -403,7 +403,6 @@ module GraphQL
 
       doc.definitions.map do |node|
         deps = Set.new
-        definitions = document_dependencies.definitions.map { |x| [x.name, x] }.to_h
 
         queue = [node.name]
         while name = queue.shift


### PR DESCRIPTION
This change removes unused local variables.
I originally created the same PR for github/graphql-ruby.






