### PR TITLE
Add and improve the tests for Date/DateTime types

### DIFF
--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -6,17 +6,7 @@ require "time" # required for Time#iso8601
 require "ostruct"
 require_relative "foo_helper"
 
-class TestQueryResult < Minitest::Test
-  class DateTimeType < GraphQL::Schema::Scalar
-    def self.coerce_input(value, ctx)
-      Time.iso8601(value)
-    end
-
-    def self.coerce_result(value, ctx)
-      value.utc.iso8601
-    end
-  end
-
+class TestQueryResult < MiniTest::Test
   module NodeType
     include GraphQL::Schema::Interface
     field :id, ID, null: false
@@ -58,7 +48,7 @@ class TestQueryResult < Minitest::Test
 
   module HumanLike
     include GraphQL::Schema::Interface
-    field :updated_at, DateTimeType, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end
 
   class PersonType < GraphQL::Schema::Object
@@ -69,7 +59,7 @@ class TestQueryResult < Minitest::Test
     field :last_name, String, null: true
     field :company, String, null: true
     field :homepageURL, String, null: true, method: :homepage_url, camelize: false
-    field :created_at, DateTimeType, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :hobbies, [String], null: true
     field :plan, PlanType, null: false
   end
@@ -596,7 +586,7 @@ class TestQueryResult < Minitest::Test
     assert_equal Time.at(1).utc, actor.updated_at
   end
 
-  def test_date_scalar_casting
+  def test_datetime_scalar_casting
     Temp.const_set :Query, @client.parse(<<-'GRAPHQL')
       {
         me {

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -60,6 +60,7 @@ class TestQueryResult < MiniTest::Test
     field :company, String, null: true
     field :homepageURL, String, null: true, method: :homepage_url, camelize: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :created_on, GraphQL::Types::ISO8601Date, null: false
     field :hobbies, [String], null: true
     field :plan, PlanType, null: false
   end
@@ -103,6 +104,7 @@ class TestQueryResult < MiniTest::Test
         last_name: "Peek",
         company: "GitHub",
         created_at: Time.at(0),
+        created_on: Date.new(1970, 1, 1),
         updated_at: Time.at(1),
         hobbies: ["soccer", "coding"],
         homepage_url: nil,
@@ -123,6 +125,7 @@ class TestQueryResult < MiniTest::Test
             last_name: "Peek",
             company: "GitHub",
             created_at: Time.at(0),
+            created_on: Date.new(1970, 1, 1),
             updated_at: Time.at(1),
             hobbies: ["soccer", "coding"],
             plan: "LARGE"
@@ -603,6 +606,23 @@ class TestQueryResult < MiniTest::Test
     assert_equal "Josh", person.name
     assert_equal Time.at(0), person.created_at
     assert_equal Time.at(1), person.updated_at
+  end
+
+  def test_date_scalar_casting
+    Temp.const_set :Query, @client.parse(<<-'GRAPHQL')
+      {
+        me {
+          name
+          createdOn
+        }
+      }
+    GRAPHQL
+
+    response = @client.query(Temp::Query)
+
+    person = response.data.me
+    assert_equal "Josh", person.name
+    assert_equal Date.new(1970, 1, 1), person.created_on
   end
 
   include FooHelper

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -6,7 +6,7 @@ require "time" # required for Time#iso8601
 require "ostruct"
 require_relative "foo_helper"
 
-class TestQueryResult < MiniTest::Test
+class TestQueryResult < Minitest::Test
   module NodeType
     include GraphQL::Schema::Interface
     field :id, ID, null: false


### PR DESCRIPTION
This change adds and improves the tests to use `GraphQL::Types::ISO8601DateTime` and `GraphQL::Types::ISO8601Date`.
I originally created the same PR for github/graphql-ruby.