### PR TITLE
add to_hash alias to to_h method of ObjectType and Response

### DIFF
--- a/lib/graphql/client/response.rb
+++ b/lib/graphql/client/response.rb
@@ -12,6 +12,7 @@ module GraphQL
       # Returns Hash.
       attr_reader :original_hash
       alias_method :to_h, :original_hash
+      alias_method :to_hash, :original_hash
 
       # Public: Wrapped ObjectType of data returned from the server.
       #

--- a/lib/graphql/client/schema/object_type.rb
+++ b/lib/graphql/client/schema/object_type.rb
@@ -192,6 +192,7 @@ module GraphQL
         def to_h
           @data
         end
+        alias :to_hash :to_h
 
         def _definer
           @definer

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -272,6 +272,7 @@ class TestQueryResult < Minitest::Test
     person = Temp::Person.new(@client.query(Temp::Query).data.me)
     raw_result = {"firstName"=>"Joshua", "lastName"=>"Peek"}
     assert_equal raw_result, person.to_h
+    assert_equal raw_result, person.to_hash
 
     assert_equal "Joshua", person.first_name
     assert_equal "Peek", person.last_name


### PR DESCRIPTION
In Rails, it's quite common to use `as_json` which relies on `to_hash` that graphql-client currently lacks. This PR introduces `to_hash` as an alias to `to_h`.

Ref: https://github.com/rails/rails/blob/3528b9df8b331863025c6ee66341b98d4989c40d/activesupport/lib/active_support/core_ext/object/json.rb#L59