### PR TITLE
Support attr readers for fields with names conflicting with Object and Kernel methods

### DIFF
--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -838,4 +838,31 @@ class TestClient < Minitest::Test
       }
     GRAPHQL
   end
+
+  def test_field_names_that_match_ruby_built_in_methods
+    query_type = Class.new(GraphQL::Schema::Object) do
+      graphql_name "Query"
+      field :things, String, null: false
+      def things
+        "things"
+      end
+
+      field :method, String, null: false
+      def method
+        "method"
+      end
+    end
+
+    schema = Class.new(GraphQL::Schema) do
+      query query_type
+    end
+
+    @client = ::GraphQL::Client.new(schema: schema, execute: schema)
+
+    Temp.const_set :Query, @client.parse("{ method things }")
+
+    result = @client.query(Temp::Query)
+    assert result.data.method == "method"
+    assert result.data.things == "things"
+  end
 end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -856,6 +856,11 @@ class TestClient < Minitest::Test
       def equal
         "equal"
       end
+
+      field :test, String, null: false
+      def test
+        "test"
+      end
     end
 
     schema = Class.new(GraphQL::Schema) do
@@ -864,12 +869,14 @@ class TestClient < Minitest::Test
 
     @client = ::GraphQL::Client.new(schema: schema, execute: schema)
 
-    Temp.const_set :Query, @client.parse("{ method things equal }")
+    Temp.const_set :Query, @client.parse("{ method things equal test }")
 
     result = @client.query(Temp::Query)
+
     assert_equal "method", result.data.method
     assert_equal "things", result.data.things
     assert_equal "equal", result.data.equal
     assert_predicate result.data, :equal?
+    assert_equal "test", result.data.test
   end
 end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -851,6 +851,11 @@ class TestClient < Minitest::Test
       def method
         "method"
       end
+
+      field :equal, String, null: false
+      def equal
+        "equal"
+      end
     end
 
     schema = Class.new(GraphQL::Schema) do
@@ -859,10 +864,12 @@ class TestClient < Minitest::Test
 
     @client = ::GraphQL::Client.new(schema: schema, execute: schema)
 
-    Temp.const_set :Query, @client.parse("{ method things }")
+    Temp.const_set :Query, @client.parse("{ method things equal }")
 
     result = @client.query(Temp::Query)
-    assert result.data.method == "method"
-    assert result.data.things == "things"
+    assert_equal "method", result.data.method
+    assert_equal "things", result.data.things
+    assert_equal "equal", result.data.equal
+    assert_predicate result.data, :equal?
   end
 end

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -243,7 +243,7 @@ class TestQueryResult < Minitest::Test
     GRAPHQL
 
     response = @client.query(Temp::Query)
-    refute response.data.me.respond_to?(:name)
+    assert response.data.me.respond_to?(:name)
     refute response.data.me.respond_to?(:company)
 
     person = Temp::Person.new(response.data.me)

--- a/test/test_query_result.rb
+++ b/test/test_query_result.rb
@@ -243,7 +243,7 @@ class TestQueryResult < Minitest::Test
     GRAPHQL
 
     response = @client.query(Temp::Query)
-    assert response.data.me.respond_to?(:name)
+    refute response.data.me.respond_to?(:name)
     refute response.data.me.respond_to?(:company)
 
     person = Temp::Person.new(response.data.me)


### PR DESCRIPTION
We currently rely on `method_missing` to provide attr readers for the fields. However, when a field has the same name as one of base Ruby methods such as `method`, `test`, `method_missing` method isn't triggered and instead Ruby invokes the corresponding base method. One can avoid this by `to_h`ing first and then accessing the data like `.to_h["method"]`.

This PR tries to implement the same access pattern for such conflicting keywords.

I am not fully convinced this is the right approach (overriding base methods and turning them into field accessor feels wrong), what if we explicitly define methods for all fields instead of relying on `method_missing`? Thinking out loud, while implementation-wise it would be improvement, we would still be overriding base methods. Alternatively, we can introduce a convention where we append `_value` suffix when there's a conflict, what do you think?

EDIT: on a second thought, seems like it's common in Ruby to override pre-existing methods like this?