### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
-
 on: [push, pull_request]
-
 jobs:
   build:
     name: Test on Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_version }}, graphql-ruby ${{ matrix.graphql_version }}
@@ -26,29 +24,28 @@ jobs:
           - "~> 7.0.0"
           - "~> 7.1.0"
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby ${{ matrix.ruby_version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-    - name: Build and test
-      run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rake test
-      env:
-        RAILS_VERSION: ${{ matrix.rails_version }}
-        GRAPHQL_VERSION: ${{ matrix.graphql_version }}
-
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Set up Ruby ${{ matrix.ruby_version }}
+        uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - name: Build and test
+        run: |
+          bundle install --jobs 4 --retry 3
+          bundle exec rake test
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
+          GRAPHQL_VERSION: ${{ matrix.graphql_version }}
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.2
-    - name: Build and test
-      run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rake rubocop
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
+        with:
+          ruby-version: 3.2
+      - name: Build and test
+        run: |-
+          bundle install --jobs 4 --retry 3
+          bundle exec rake rubocop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Release
-
 on:
   release:
     types: [published]
   workflow_dispatch:
-
 jobs:
   release:
     name: Release to RubyGems
@@ -13,9 +11,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
         with:
           bundler-cache: true
           ruby-version: ruby
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@612653d273a73bdae1df8453e090060bb4db5f31 # v1


### PR DESCRIPTION
- [x] add dependabot config
  - group dependency updates when minor/patch to reduce PRs
  - keep major dependency updates separate for visibility and testing
- [x] change workflow actions to SHAs instead of tags to secure supply chain
  - tags are mutable and malicious code could be injected, SHAs are immutable
  - format workflows
  - used [frizbee](https://github.com/stacklok/frizbee) locally to do this
    - `frizbee ghactions -d .github/workflows`