### PR TITLE
feat: Enable consumers to access the full response payload

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -380,12 +380,11 @@ module GraphQL
         error_payload = payload.merge(message: error["message"], error: error)
         ActiveSupport::Notifications.instrument("error.graphql", error_payload)
       end
- 
       Response.new(
         result,
         data: definition.new(data, Errors.new(errors, ["data"])),
         errors: Errors.new(errors),
-        extensions:,
+        extensions: extensions,
         full_response: execute.respond_to?("last_response") ? execute.last_response : nil
       )
     end

--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -380,12 +380,13 @@ module GraphQL
         error_payload = payload.merge(message: error["message"], error: error)
         ActiveSupport::Notifications.instrument("error.graphql", error_payload)
       end
-
+ 
       Response.new(
         result,
         data: definition.new(data, Errors.new(errors, ["data"])),
         errors: Errors.new(errors),
-        extensions: extensions
+        extensions:,
+        full_response: execute.respond_to?("last_response") ? execute.last_response : nil
       )
     end
 

--- a/lib/graphql/client/http.rb
+++ b/lib/graphql/client/http.rb
@@ -45,6 +45,11 @@ module GraphQL
         {}
       end
 
+      # Public: full reponse from last request
+      #
+      # Returns Hash.
+      attr_reader :last_response
+
       # Public: Make an HTTP request for GraphQL query.
       #
       # Implements Client's "execute" adapter interface.
@@ -71,6 +76,7 @@ module GraphQL
         request.body = JSON.generate(body)
 
         response = connection.request(request)
+        @last_response = response.to_hash
         case response
         when Net::HTTPOK, Net::HTTPBadRequest
           JSON.parse(response.body)

--- a/lib/graphql/client/response.rb
+++ b/lib/graphql/client/response.rb
@@ -31,12 +31,18 @@ module GraphQL
       # Public: Hash of server specific extension metadata.
       attr_reader :extensions
 
+      # Public: Complete response hash returned from server.
+      #
+      # Returns Hash
+      attr_reader :full_response
+
       # Internal: Initialize base class.
-      def initialize(hash, data: nil, errors: Errors.new, extensions: {})
+      def initialize(hash, data: nil, errors: Errors.new, extensions: {}, full_response: nil)
         @original_hash = hash
         @data = data
         @errors = errors
         @extensions = extensions
+        @full_response = full_response
       end
     end
   end


### PR DESCRIPTION
Update the Response public API object to include full_response. this is non-breaking.

Passing the full response from the executing object to the client is currently done via the client checking with the object, versus it being part of the response, 

In order to change this it requires changing the much more changes, as all the tests are using GraphQL::Schema for the execution of the graphql