### PR TITLE
Allow loading schema from SDL definition file as well as JSON

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -54,8 +54,12 @@ module GraphQL
       when String
         if schema.end_with?(".json") && File.exist?(schema)
           load_schema(File.read(schema))
+        elsif (schema.end_with?(".graphql", ".graphqls")) && File.exist?(schema)
+          GraphQL::Schema.from_definition(schema)
         elsif schema =~ /\A\s*{/
           load_schema(JSON.parse(schema, freeze: true))
+        elsif schema.start_with?("schema")
+          GraphQL::Schema.from_definition(schema)
         end
       else
         if schema.respond_to?(:execute)

--- a/test/test_client_schema.rb
+++ b/test/test_client_schema.rb
@@ -42,6 +42,22 @@ class TestClientSchema < Minitest::Test
     assert_equal "AwesomeQuery", schema.query.graphql_name
   end
 
+  def test_load_schema_from_definition_string
+    definition = Schema.to_definition
+    schema = GraphQL::Client.load_schema(definition)
+    assert_equal "AwesomeQuery", schema.query.graphql_name
+  end
+
+  def test_load_schema_from_definition_file
+    definition = Schema.to_definition
+    Tempfile.create(["schema", ".graphql"]) do |file|
+      file.write(definition)
+      file.close
+      schema = GraphQL::Client.load_schema(file.path)
+      assert_equal "AwesomeQuery", schema.query.graphql_name
+    end
+  end
+
   def test_load_schema_ignores_missing_path
     refute GraphQL::Client.load_schema("#{__dir__}/missing-schema.json")
   end


### PR DESCRIPTION
If passing a path to a file with a name that ends in ".graphql" or ".graphqls" (matching the filenames used in
[graphql-ruby](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/schema.rb#L116)), attempt to load the schema from that file assuming it's a schema definition rather than a JSON schema.