### PR TITLE
Bump RuboCop and fix deprecation warnings

### DIFF
--- a/graphql-client.gemspec
+++ b/graphql-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.9"
   s.add_development_dependency "rake", "~> 13.2.1"
   s.add_development_dependency "rubocop-github"
-  s.add_development_dependency "rubocop", "~> 1.66.1"
+  s.add_development_dependency "rubocop", "~> 1.73.2"
 
   s.required_ruby_version = ">= 2.1.0"
 

--- a/lib/rubocop/cop/graphql/heredoc.rb
+++ b/lib/rubocop/cop/graphql/heredoc.rb
@@ -19,11 +19,11 @@ module RuboCop
           return unless node.location.expression.source =~ /^<<(-|~)?GRAPHQL/
 
           node.each_child_node(:begin) do |begin_node|
-            add_offense(begin_node, location: :expression, message: "Do not interpolate variables into GraphQL queries, " \
+            add_offense(begin_node, message: "Do not interpolate variables into GraphQL queries, " \
               "used variables instead.")
           end
 
-          add_offense(node, location: :expression, message: "GraphQL heredocs should be quoted. <<-'GRAPHQL'")
+          add_offense(node, message: "GraphQL heredocs should be quoted. <<-'GRAPHQL'")
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/graphql/heredoc.rb
+++ b/lib/rubocop/cop/graphql/heredoc.rb
@@ -5,7 +5,7 @@ module RuboCop
   module Cop
     module GraphQL
       # Public: Cop for enforcing non-interpolated GRAPHQL heredocs.
-      class Heredoc < Cop
+      class Heredoc < Base
         def on_dstr(node)
           check_str(node)
         end

--- a/lib/rubocop/cop/graphql/overfetch.rb
+++ b/lib/rubocop/cop/graphql/overfetch.rb
@@ -42,7 +42,7 @@ module RuboCop
 
           visitor.fields.each do |field, count|
             next if count > 0
-            add_offense(nil, location: visitor.ranges[field], message: "GraphQL field '#{field}' query but was not used in template.")
+            add_offense(nil, message: "GraphQL field '#{field}' query but was not used in template.")
           end
         end
 

--- a/lib/rubocop/cop/graphql/overfetch.rb
+++ b/lib/rubocop/cop/graphql/overfetch.rb
@@ -8,7 +8,7 @@ module RuboCop
   module Cop
     module GraphQL
       # Public: Rubocop for catching overfetched fields in ERB templates.
-      class Overfetch < Cop
+      class Overfetch < Base
         if defined?(RangeHelp)
           # rubocop 0.53 moved the #source_range method into this module
           include RangeHelp


### PR DESCRIPTION
- Bumps RuboCop and fix deprecations so we stop getting warnings from this gem in projects that use a greater RuboCop version.
- Supersedes #64.

```text
warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html

An error occurred while GraphQL/Heredoc cop was inspecting /Users/issyl0/repos/github/graphql-client/test/test_client.rb:724:19.
unknown keyword: :location
```