### PR TITLE
docs: fix variable name in dynamic query error guide example

### DIFF
--- a/guides/dynamic-query-error.md
+++ b/guides/dynamic-query-error.md
@@ -23,7 +23,7 @@ hero_query = SWAPI::Client.parse <<-'GRAPHQL'
     }
   }
 GRAPHQL
-result = SWAPI::Client.query(HeroNameQuery, variables: { id: params[:id] })
+result = SWAPI::Client.query(hero_query, variables: { id: params[:id] })
 ```
 
 Parsing a query and validating a query on every request adds performance overhead. It also prevents validation errors from being discovered until request time, rather than when the query is parsed at startup.


### PR DESCRIPTION
## Summary
Fixed an incorrect variable reference in the sample code of `guides/dynamic-query-error.md`.

The query result was assigned to a local variable `hero_query`, but the subsequent `Client.query` call mistakenly referenced it as the constant `HeroNameQuery`.

Updated the reference to use the correct local variable `hero_query`.