### PR TITLE
Fix inline fragments without a space before "on"

### DIFF
--- a/lib/graphql/client.rb
+++ b/lib/graphql/client.rb
@@ -153,8 +153,12 @@ module GraphQL
 
       # Replace Ruby constant reference with GraphQL fragment names,
       # while populating `definition_dependencies` with
-      # GraphQL Fragment ASTs which this operation depends on
-      str = str.gsub(/\.\.\.([a-zA-Z0-9_]+(::[a-zA-Z0-9_]+)*)/) do
+      # GraphQL Fragment ASTs which this operation depends on.
+      #
+      # GraphQL forbids naming a fragment "on", so "...on" followed by a word
+      # boundary is unambiguously an inline fragment, never a spread
+      # referencing constant "On".
+      str = str.gsub(/\.\.\.(?!on\b)([a-zA-Z0-9_]+(::[a-zA-Z0-9_]+)*)/) do
         match = Regexp.last_match
         const_name = match[1]
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -159,6 +159,40 @@ class TestClient < Minitest::Test
     assert_equal(query_string, Temp::UserQuery.document.to_query_string)
   end
 
+  def test_client_parse_inline_fragment_without_space_before_on
+    Temp.const_set :NodeQuery, @client.parse(<<-'GRAPHQL')
+      query {
+        node(id: "1") {
+          id
+          ...on User {
+            name
+          }
+          ... on Organization {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    query_string = <<-'GRAPHQL'.gsub(/^      /, "").chomp
+      query TestClient__Temp__NodeQuery {
+        node(id: "1") {
+          __typename
+          id
+          ... on User {
+            name
+          }
+          ... on Organization {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    assert_equal(query_string, @client.document.to_query_string)
+    assert_equal(query_string, Temp::NodeQuery.document.to_query_string)
+  end
+
   def test_client_parse_query_document
     Temp.const_set :UserDocument, @client.parse(<<-'GRAPHQL')
       query GetUser {


### PR DESCRIPTION
## What

`Client#parse`'s fragment-spread regex (`/\.\.\.([a-zA-Z0-9_]+(::[a-zA-Z0-9_]+)*)/`) matches `...on Type` (no space) as a spread referencing a Ruby constant named `On`, since it only requires the identifier to immediately follow the three dots — it doesn't distinguish that from an inline fragment written without a space before `on`.

Both `...on Type { ... }` and `... on Type { ... }` are valid, equivalent GraphQL — whitespace between `...` and `on` is optional per the spec. But only the spaced form parses correctly today; the unspaced form raises:

```
GraphQL::Client::ValidationError: uninitialized constant on
```

## Why this is safe to fix with a lookahead

The GraphQL spec explicitly forbids naming a fragment `on`:

> FragmentName : Name **but not** `on`

So `...on` immediately followed by a word boundary can never be a legitimate fragment-spread reference — it's unambiguously an inline fragment. This PR adds a negative lookahead (`(?!on\b)`) to the regex to skip exactly that case, leaving every other fragment name (including ones that start with `on`, like `onFragment`, or literally named `On` with a capital O) unaffected.

## Testing

Added `test_client_parse_inline_fragment_without_space_before_on`, which fails against `master` with the `ValidationError` above and passes with this fix. Ran the full `test/test_client.rb` suite locally — 17 runs, 0 failures, 0 errors (3 pre-existing skips, unrelated).
